### PR TITLE
Add crashed Gravship world sites, incident, settings, and dev tools

### DIFF
--- a/1.6/Defs/Factions/Faction_GravshipSurvivors.xml
+++ b/1.6/Defs/Factions/Faction_GravshipSurvivors.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Defs>
+  <FactionDef>
+    <defName>Gravship_Survivors</defName>
+    <label>gravship survivors</label>
+    <description>Desperate survivors clinging to the wreckage of their gravship. They are hostile and heavily armed.</description>
+    <factionClass>Faction</factionClass>
+    <techLevel>Spacer</techLevel>
+    <permanentEnemy>true</permanentEnemy>
+    <humanlikeFaction>true</humanlikeFaction>
+    <hidden>true</hidden>
+    <requiredCountAtGameStart>0</requiredCountAtGameStart>
+    <canMakeRandomly>false</canMakeRandomly>
+    <startingGoodwill> -75 </startingGoodwill>
+    <factionIconPath>UI/Icons/Factions/FactionPirate</factionIconPath>
+    <colorFromSpectrum>1.1</colorFromSpectrum>
+  </FactionDef>
+</Defs>

--- a/1.6/Defs/Incidents/Incidents_GravshipCrashes.xml
+++ b/1.6/Defs/Incidents/Incidents_GravshipCrashes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Defs>
+  <IncidentDef>
+    <defName>CrashedGravshipIncident</defName>
+    <label>crashed gravship</label>
+    <category>Misc</category>
+    <target>World</target>
+    <workerClass>GravshipCrashes.Incident.IncidentWorker_CrashedGravship</workerClass>
+    <baseChance>0.4</baseChance>
+    <mtbDays>3</mtbDays>
+    <letterLabel>Crashed gravship spotted</letterLabel>
+    <letterText>A gravship has crashed nearby, scattering debris, survivors, and potential salvage. You can send a caravan to investigate before the crash site is picked clean.</letterText>
+    <letterDef>PositiveEvent</letterDef>
+  </IncidentDef>
+</Defs>

--- a/1.6/Defs/Sites/SiteParts_GravshipCrashes.xml
+++ b/1.6/Defs/Sites/SiteParts_GravshipCrashes.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Defs>
+  <SitePartDef>
+    <defName>CrashedGravshipSitePart</defName>
+    <label>crashed gravship</label>
+    <workerClass>GravshipCrashes.Sites.SitePartWorker_CrashedGravship</workerClass>
+    <wantsThreatPoints>true</wantsThreatPoints>
+  </SitePartDef>
+
+  <WorldObjectDef>
+    <defName>CrashedGravshipSite</defName>
+    <label>crashed gravship</label>
+    <description>A smouldering gravship wreck. Hostile survivors and valuable salvage are likely present.</description>
+    <class>RimWorld.Planet.Site</class>
+    <expandingIconTexture>World/WorldObjects/Site</expandingIconTexture>
+    <comps>
+      <li Class="RimWorld.Planet.WorldObjectCompProperties_Timeout" />
+      <li Class="GravshipCrashes.Util.WorldObjectCompProperties_CrashedGravship" />
+    </comps>
+    <siteParts>
+      <li>CrashedGravshipSitePart</li>
+    </siteParts>
+  </WorldObjectDef>
+</Defs>

--- a/1.6/Defs/ThingSetMakers/ThingSetMakers_GravshipCrashes.xml
+++ b/1.6/Defs/ThingSetMakers/ThingSetMakers_GravshipCrashes.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Defs>
+  <ThingSetMakerDef>
+    <defName>GravshipCrashLoot</defName>
+    <label>gravship crash loot</label>
+    <root Class="ThingSetMaker_Sum">
+      <options>
+        <li>
+          <thingSetMaker Class="ThingSetMaker_Count">
+            <thingDef>ComponentIndustrial</thingDef>
+            <countRange>
+              <min>6</min>
+              <max>14</max>
+            </countRange>
+          </thingSetMaker>
+        </li>
+        <li>
+          <thingSetMaker Class="ThingSetMaker_Count">
+            <thingDef>Plasteel</thingDef>
+            <countRange>
+              <min>20</min>
+              <max>60</max>
+            </countRange>
+          </thingSetMaker>
+        </li>
+        <li>
+          <thingSetMaker Class="ThingSetMaker_Count">
+            <thingDef>ComponentSpacer</thingDef>
+            <countRange>
+              <min>2</min>
+              <max>5</max>
+            </countRange>
+          </thingSetMaker>
+          <selectionWeight>0.4</selectionWeight>
+        </li>
+        <li>
+          <thingSetMaker Class="ThingSetMaker_Count">
+            <thingDef>MedicineUltratech</thingDef>
+            <countRange>
+              <min>2</min>
+              <max>5</max>
+            </countRange>
+          </thingSetMaker>
+          <selectionWeight>0.35</selectionWeight>
+        </li>
+        <li>
+          <thingSetMaker Class="ThingSetMaker_Count">
+            <thingDef>Steel</thingDef>
+            <countRange>
+              <min>35</min>
+              <max>120</max>
+            </countRange>
+          </thingSetMaker>
+        </li>
+      </options>
+    </root>
+  </ThingSetMakerDef>
+</Defs>

--- a/1.6/Source/GravshipCrashes.csproj
+++ b/1.6/Source/GravshipCrashes.csproj
@@ -85,6 +85,19 @@
     <Compile Include="ResourceBank.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="TraitEntry.cs" />
+    <Compile Include="GravshipCrashes\Settings\ModSettings_GravshipCrashes.cs" />
+    <Compile Include="GravshipCrashes\Settings\Mod_GravshipCrashes.cs" />
+    <Compile Include="GravshipCrashes\Util\ShipLayoutResolver.cs" />
+    <Compile Include="GravshipCrashes\Util\GravshipLayoutSpawner.cs" />
+    <Compile Include="GravshipCrashes\Util\GravshipSpawnUtility.cs" />
+    <Compile Include="GravshipCrashes\Util\GravshipCrashesDefOf.cs" />
+    <Compile Include="GravshipCrashes\Util\DefenderGen.cs" />
+    <Compile Include="GravshipCrashes\Incident\IncidentWorker_CrashedGravship.cs" />
+    <Compile Include="GravshipCrashes\Sites\SitePartWorker_CrashedGravship.cs" />
+    <Compile Include="GravshipCrashes\Sites\MapGenerator_CrashedGravship.cs" />
+    <Compile Include="GravshipCrashes\Sites\WorldObjectComp_CrashedGravship.cs" />
+    <Compile Include="GravshipCrashes\Debug\DebugActionsWorld_CrashedGravship.cs" />
+    <Compile Include="GravshipCrashes\Harmony\Patches_ReadmeIfNeeded.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="GravshipCrashes\" />

--- a/1.6/Source/GravshipCrashes/Debug/DebugActionsWorld_CrashedGravship.cs
+++ b/1.6/Source/GravshipCrashes/Debug/DebugActionsWorld_CrashedGravship.cs
@@ -1,0 +1,50 @@
+using GravshipCrashes.Settings;
+using GravshipCrashes.Util;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace GravshipCrashes.Debug
+{
+    /// <summary>
+    /// Adds world debug tools for testing crashed gravship sites.
+    /// </summary>
+    public static class DebugActionsWorld_CrashedGravship
+    {
+        [DebugAction("Gravship Crashes", "Spawn Crashed Gravship Site (Dev)", allowedGameStates = AllowedGameStates.WorldView, requiresDevMode = true)]
+        public static void SpawnCrashedGravshipSite()
+        {
+            var settings = Mod_GravshipCrashes.Instance?.Settings;
+            if (settings != null && !settings.devEnableWorldSpawnButton)
+            {
+                Messages.Message("Dev spawn disabled in settings.", MessageTypeDefOf.RejectInput, false);
+                return;
+            }
+
+            ShipLayoutResolver.RefreshIfNeeded();
+            var allowedShips = ShipLayoutResolver.AllowedShips(settings);
+            if (allowedShips.Count == 0)
+            {
+                Messages.Message("No gravship layouts are currently enabled.", MessageTypeDefOf.RejectInput, false);
+                return;
+            }
+
+            var tile = Find.WorldSelector.SelectedTile;
+            if (tile < 0 || !TileFinder.IsValidTileForNewSettlement(tile))
+            {
+                if (!GravshipSpawnUtility.TryFindSiteTile(out tile))
+                {
+                    Messages.Message("Could not find a valid tile for the crash site.", MessageTypeDefOf.RejectInput, false);
+                    return;
+                }
+            }
+
+            var entry = allowedShips.RandomElement();
+            var site = GravshipSpawnUtility.CreateSite(tile);
+            GravshipSpawnUtility.ConfigureSiteMetadata(site, entry);
+            GravshipSpawnUtility.ConfigureTimeout(site, new IntRange(6, 10));
+            Find.WorldObjects.Add(site);
+            Messages.Message("Spawned crashed gravship site.", new GlobalTargetInfo(site.Tile), MessageTypeDefOf.PositiveEvent);
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Harmony/Patches_ReadmeIfNeeded.cs
+++ b/1.6/Source/GravshipCrashes/Harmony/Patches_ReadmeIfNeeded.cs
@@ -1,0 +1,9 @@
+namespace GravshipCrashes.Harmony
+{
+    /// <summary>
+    /// Placeholder file to keep the Harmony folder tracked.
+    /// </summary>
+    internal static class Patches_ReadmeIfNeeded
+    {
+    }
+}

--- a/1.6/Source/GravshipCrashes/Incident/IncidentWorker_CrashedGravship.cs
+++ b/1.6/Source/GravshipCrashes/Incident/IncidentWorker_CrashedGravship.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using GravshipCrashes.Settings;
+using GravshipCrashes.Sites;
+using GravshipCrashes.Util;
+using RimWorld;
+using RimWorld.Planet;
+using UnityEngine;
+using Verse;
+
+namespace GravshipCrashes.Incident
+{
+    /// <summary>
+    /// Storyteller incident that creates a crashed gravship world site.
+    /// </summary>
+    public class IncidentWorker_CrashedGravship : IncidentWorker
+    {
+        protected override bool CanFireNowSub(IncidentParms parms)
+        {
+            ShipLayoutResolver.RefreshIfNeeded();
+
+            if (!ShipLayoutResolver.HasExporterContent)
+            {
+                return false;
+            }
+
+            var settings = Mod_GravshipCrashes.Instance?.Settings;
+            if (settings != null)
+            {
+                def.baseChance = Mathf.Max(0f, settings.incidentBaseChance);
+                def.mtbDays = Mathf.Max(0.1f, settings.daysBetweenCrashChecks);
+            }
+
+            var allowedShips = ShipLayoutResolver.AllowedShips(settings);
+            return allowedShips.Count > 0;
+        }
+
+        protected override bool TryExecuteWorker(IncidentParms parms)
+        {
+            var settings = Mod_GravshipCrashes.Instance?.Settings;
+            var allowedShips = ShipLayoutResolver.AllowedShips(settings);
+            if (allowedShips.Count == 0)
+            {
+                return false;
+            }
+
+            if (!GravshipSpawnUtility.TryFindSiteTile(out var tile))
+            {
+                return false;
+            }
+
+            var shipEntry = allowedShips.RandomElement();
+            var site = GravshipSpawnUtility.CreateSite(tile);
+            GravshipSpawnUtility.ConfigureSiteMetadata(site, shipEntry);
+            GravshipSpawnUtility.ConfigureTimeout(site, new IntRange(12, 20));
+            Find.WorldObjects.Add(site);
+
+            var letterLabel = "Crashed Gravship";
+            var letterText = "A gravship has crashed nearby, spilling survivors and salvage across the landscape.";
+            SendStandardLetter(letterLabel, letterText, LetterDefOf.PositiveEvent, parms, site);
+            return true;
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Settings/Mod_GravshipCrashes.cs
+++ b/1.6/Source/GravshipCrashes/Settings/Mod_GravshipCrashes.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using GravshipCrashes.Util;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace GravshipCrashes.Settings
+{
+    /// <summary>
+    /// Entry point that exposes the mod settings and settings UI.
+    /// </summary>
+    public class Mod_GravshipCrashes : Mod
+    {
+        public static Mod_GravshipCrashes Instance { get; private set; }
+
+        public ModSettings_GravshipCrashes Settings { get; }
+
+        private Vector2 shipScrollPosition = Vector2.zero;
+
+        public Mod_GravshipCrashes(ModContentPack content) : base(content)
+        {
+            Instance = this;
+            Settings = GetSettings<ModSettings_GravshipCrashes>();
+            ShipLayoutResolver.RefreshIfNeeded();
+            Settings.SynchroniseShips(ShipLayoutResolver.AllShipsDefNames);
+        }
+
+        public override string SettingsCategory()
+        {
+            return "Gravship Crashes";
+        }
+
+        public override void DoSettingsWindowContents(Rect inRect)
+        {
+            var listing = new Listing_Standard();
+            listing.Begin(inRect);
+
+            listing.Label("Storyteller".Translate());
+            listing.Label("Days Between Crash Checks: " + Settings.daysBetweenCrashChecks.ToString("0.0"));
+            Settings.daysBetweenCrashChecks = listing.Slider(Settings.daysBetweenCrashChecks, 0.25f, 20f);
+            listing.Label("Incident Base Chance: " + Settings.incidentBaseChance.ToStringPercent());
+            Settings.incidentBaseChance = listing.Slider(Settings.incidentBaseChance, 0f, 1f);
+
+            listing.GapLine();
+            listing.Label("Crash Damage".Translate());
+            listing.Label("Structural Damage Min: " + Settings.shipStructureDamageRange.min.ToStringPercent());
+            Settings.shipStructureDamageRange.min = listing.Slider(Settings.shipStructureDamageRange.min, 0f, 1f);
+            listing.Label("Structural Damage Max: " + Settings.shipStructureDamageRange.max.ToStringPercent());
+            Settings.shipStructureDamageRange.max = listing.Slider(Settings.shipStructureDamageRange.max, Settings.shipStructureDamageRange.min, 1f);
+            listing.Label("Thing Damage Min: " + Settings.thingDamageRange.min.ToStringPercent());
+            Settings.thingDamageRange.min = listing.Slider(Settings.thingDamageRange.min, 0f, 1f);
+            listing.Label("Thing Damage Max: " + Settings.thingDamageRange.max.ToStringPercent());
+            Settings.thingDamageRange.max = listing.Slider(Settings.thingDamageRange.max, Settings.thingDamageRange.min, 1f);
+
+            listing.Gap();
+            listing.Label("Defenders".Translate());
+            listing.Label("Pawn Injury Severity Min: " + Settings.pawnInjurySeverityRange.min.ToStringPercent());
+            Settings.pawnInjurySeverityRange.min = listing.Slider(Settings.pawnInjurySeverityRange.min, 0f, 1f);
+            listing.Label("Pawn Injury Severity Max: " + Settings.pawnInjurySeverityRange.max.ToStringPercent());
+            Settings.pawnInjurySeverityRange.max = listing.Slider(Settings.pawnInjurySeverityRange.max, Settings.pawnInjurySeverityRange.min, 1f);
+            listing.IntAdjuster(ref Settings.maxDefenders, 1, 1);
+            listing.Label("Max defenders: " + Settings.maxDefenders);
+
+            listing.GapLine();
+            listing.CheckboxLabeled("Enable Dev Spawn Button", ref Settings.devEnableWorldSpawnButton, "If enabled, a debug action is added on the world map to instantly spawn a crashed gravship site.");
+
+            listing.GapLine();
+            listing.Label("Available Ships".Translate());
+
+            DrawShipSelection(listing);
+
+            listing.End();
+        }
+
+        private void DrawShipSelection(Listing_Standard listing)
+        {
+            var ships = ShipLayoutResolver.AllShips;
+            Settings.SynchroniseShips(ShipLayoutResolver.AllShipsDefNames);
+
+            if (!ShipLayoutResolver.HasExporterContent)
+            {
+                listing.Label("Gravship Exporter content not found. Enable the exporter mod to unlock gravship crash sites.");
+                return;
+            }
+
+            if (ships.Count == 0)
+            {
+                listing.Label("No ShipLayoutDefV2 defs were discovered. Ensure the exporter mod is loaded.");
+                return;
+            }
+
+            var rect = listing.GetRect(220f);
+            var view = new Rect(0f, 0f, rect.width - 16f, ships.Count * 24f);
+            Widgets.BeginScrollView(rect, ref shipScrollPosition, view);
+            var curY = 0f;
+            foreach (var ship in ships)
+            {
+                var row = new Rect(0f, curY, view.width, 24f);
+                bool allowed = Settings.AllowsShip(ship.DefName);
+                Widgets.CheckboxLabeled(row, ship.LabelWithSource, ref allowed);
+                Settings.SetAllowsShip(ship.DefName, allowed);
+                curY += 24f;
+            }
+
+            Widgets.EndScrollView();
+        }
+
+        public override void WriteSettings()
+        {
+            base.WriteSettings();
+            ShipLayoutResolver.NotifySettingsChanged();
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Sites/MapGenerator_CrashedGravship.cs
+++ b/1.6/Source/GravshipCrashes/Sites/MapGenerator_CrashedGravship.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using GravshipCrashes.Settings;
+using GravshipCrashes.Util;
+using RimWorld;
+using RimWorld.Planet;
+using UnityEngine;
+using Verse;
+
+namespace GravshipCrashes.Sites
+{
+    /// <summary>
+    /// Responsible for placing the crashed gravship, damage, loot and defenders on the generated map.
+    /// </summary>
+    public static class MapGenerator_CrashedGravship
+    {
+        public static void Generate(Map map, Site site, ShipLayoutResolver.ShipEntry shipEntry)
+        {
+            var settings = Mod_GravshipCrashes.Instance?.Settings;
+            var comp = site.GetComponent<WorldObjectComp_CrashedGravship>();
+
+            var usedRect = CellRect.CenteredOn(map.Center, 30, 30);
+            var placedThings = new List<Thing>();
+
+            if (shipEntry != null && GravshipLayoutSpawner.TrySpawnLayout(map, shipEntry, usedRect.CenterCell, placedThings))
+            {
+                usedRect = GravshipLayoutSpawner.CalculateBounds(placedThings, map);
+            }
+            else
+            {
+                GenerateFallbackHull(map, usedRect);
+            }
+
+            GravshipSpawnUtility.RemoveGravEngines(map, usedRect.Cells);
+            GravshipSpawnUtility.ApplyStructureDamage(map, settings?.shipStructureDamageRange ?? new FloatRange(0.15f, 0.45f), comp?.StructureDamageSeed ?? Rand.Int);
+            GravshipSpawnUtility.ApplyThingDamage(map, settings?.thingDamageRange ?? new FloatRange(0.1f, 0.35f), comp?.ThingDamageSeed ?? Rand.Int);
+            GravshipSpawnUtility.ScatterDebris(map, usedRect, comp?.StructureDamageSeed ?? Rand.Int);
+            GravshipSpawnUtility.SpawnLoot(map, usedRect, comp?.LootSeed ?? Rand.Int);
+
+            DefenderGen.SpawnDefenders(map, usedRect, settings);
+        }
+
+        private static void GenerateFallbackHull(Map map, CellRect rect)
+        {
+            rect = rect.ClipInsideMap(map);
+            foreach (var cell in rect.EdgeCells)
+            {
+                var wall = ThingMaker.MakeThing(ThingDefOf.Wall, ThingDefOf.Plasteel);
+                GenSpawn.Spawn(wall, cell, map, WipeMode.Vanish);
+            }
+
+            foreach (var cell in rect.Cells.InRandomOrder())
+            {
+                if (!cell.InBounds(map) || !cell.Standable(map))
+                {
+                    continue;
+                }
+
+                if (Rand.Chance(0.2f))
+                {
+                    var floor = TerrainDefOf.MetalTile;
+                    map.terrainGrid.SetTerrain(cell, floor);
+                }
+            }
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Sites/SitePartWorker_CrashedGravship.cs
+++ b/1.6/Source/GravshipCrashes/Sites/SitePartWorker_CrashedGravship.cs
@@ -1,0 +1,42 @@
+using GravshipCrashes.Util;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace GravshipCrashes.Sites
+{
+    /// <summary>
+    /// Coordinates map generation for the crashed gravship site part.
+    /// </summary>
+    public class SitePartWorker_CrashedGravship : SitePartWorker
+    {
+        public override void PostMapGenerate(Map map)
+        {
+            base.PostMapGenerate(map);
+
+            if (map?.Parent is not Site site)
+            {
+                return;
+            }
+
+            var comp = site.GetComponent<WorldObjectComp_CrashedGravship>();
+            ShipLayoutResolver.ShipEntry entry = null;
+            if (comp != null && ShipLayoutResolver.TryGetEntry(comp.ShipDefName, out var resolved))
+            {
+                entry = resolved;
+            }
+
+            MapGenerator_CrashedGravship.Generate(map, site, entry);
+        }
+
+        public override void SiteRemoved(Site site)
+        {
+            base.SiteRemoved(site);
+            var comp = site.GetComponent<WorldObjectComp_CrashedGravship>();
+            if (comp != null)
+            {
+                comp.ShipDefName = string.Empty;
+            }
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Sites/WorldObjectComp_CrashedGravship.cs
+++ b/1.6/Source/GravshipCrashes/Sites/WorldObjectComp_CrashedGravship.cs
@@ -1,0 +1,35 @@
+using RimWorld.Planet;
+using Verse;
+
+namespace GravshipCrashes.Util
+{
+    /// <summary>
+    /// Stores per-site data required to generate the crashed gravship map.
+    /// </summary>
+    public class WorldObjectComp_CrashedGravship : WorldObjectComp
+    {
+        public string ShipDefName = string.Empty;
+        public int StructureDamageSeed;
+        public int ThingDamageSeed;
+        public int LootSeed;
+        public int DefenderSeed;
+
+        public override void PostExposeData()
+        {
+            base.PostExposeData();
+            Scribe_Values.Look(ref ShipDefName, nameof(ShipDefName));
+            Scribe_Values.Look(ref StructureDamageSeed, nameof(StructureDamageSeed));
+            Scribe_Values.Look(ref ThingDamageSeed, nameof(ThingDamageSeed));
+            Scribe_Values.Look(ref LootSeed, nameof(LootSeed));
+            Scribe_Values.Look(ref DefenderSeed, nameof(DefenderSeed));
+        }
+    }
+
+    public class WorldObjectCompProperties_CrashedGravship : WorldObjectCompProperties
+    {
+        public WorldObjectCompProperties_CrashedGravship()
+        {
+            compClass = typeof(WorldObjectComp_CrashedGravship);
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Util/DefenderGen.cs
+++ b/1.6/Source/GravshipCrashes/Util/DefenderGen.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.Linq;
+using GravshipCrashes.Settings;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace GravshipCrashes.Util
+{
+    /// <summary>
+    /// Spawns defender pawns for the crashed gravship site.
+    /// </summary>
+    public static class DefenderGen
+    {
+        private static Faction cachedFaction;
+
+        public static void SpawnDefenders(Map map, CellRect area, ModSettings_GravshipCrashes settings)
+        {
+            var faction = EnsureFaction();
+            if (faction == null)
+            {
+                return;
+            }
+
+            Rand.PushState(map.Tile + 1337);
+            try
+            {
+                var maxDefenders = settings?.maxDefenders ?? 6;
+                var count = Mathf.Clamp(Rand.RangeInclusive(Mathf.Min(2, maxDefenders), maxDefenders), 1, maxDefenders);
+                var pawns = new List<Pawn>();
+                for (var i = 0; i < count; i++)
+                {
+                    var request = new PawnGenerationRequest(PawnKindDefOf.SpaceSoldier, faction, PawnGenerationContext.NonPlayer, map.Tile,
+                        allowDowned: false, forceGenerateNewPawn: true, canGeneratePawnRelations: false, mustBeCapableOfViolence: true,
+                        fixedGender: Gender.None, fixedIdeo: faction.ideos?.PrimaryIdeo, allowFood: false, allowPregnant: false,
+                        allowLactating: false, mustBeCapableOfViolenceIfAdult: true);
+
+                    var pawn = PawnGenerator.GeneratePawn(request);
+                    PawnWeaponGenerator.TryGenerateWeaponFor(pawn);
+                    if (pawn.apparel == null || pawn.apparel.WornApparelCount == 0)
+                    {
+                        PawnApparelGenerator.GenerateStartingApparelFor(pawn);
+                    }
+
+                    ApplyCrashInjuries(pawn, settings?.pawnInjurySeverityRange ?? new FloatRange(0.1f, 0.4f));
+                    pawns.Add(pawn);
+                }
+
+                var cells = area.Cells.Where(c => c.InBounds(map) && c.Standable(map)).InRandomOrder().ToList();
+                foreach (var pawn in pawns)
+                {
+                    IntVec3 cell;
+                    if (cells.Count > 0)
+                    {
+                        cell = cells[cells.Count - 1];
+                        cells.RemoveAt(cells.Count - 1);
+                    }
+                    else
+                    {
+                        cell = CellFinder.RandomClosewalkCellNear(area.CenterCell, map, 10);
+                    }
+
+                    GenSpawn.Spawn(pawn, cell, map);
+                }
+            }
+            finally
+            {
+                Rand.PopState();
+            }
+        }
+
+        private static void ApplyCrashInjuries(Pawn pawn, FloatRange severity)
+        {
+            if (pawn == null)
+            {
+                return;
+            }
+
+            var injuryFraction = Mathf.Clamp01(severity.RandomInRange);
+            if (injuryFraction <= 0f)
+            {
+                return;
+            }
+
+            var bodyParts = pawn.health.hediffSet.GetNotMissingParts().Where(p => p.depth == BodyPartDepth.Outside).ToList();
+            if (bodyParts.Count == 0)
+            {
+                return;
+            }
+
+            var injuries = Rand.RangeInclusive(1, 4);
+            for (var i = 0; i < injuries; i++)
+            {
+                var part = bodyParts.RandomElement();
+                var hediff = HediffMaker.MakeHediff(HediffDefOf.Bruise, pawn, part);
+                hediff.Severity = Mathf.Clamp(injuryFraction * Rand.Range(0.4f, 1.1f), 0.05f, 0.8f);
+                pawn.health.AddHediff(hediff);
+            }
+        }
+
+        private static Faction EnsureFaction()
+        {
+            if (cachedFaction != null && !cachedFaction.defeated)
+            {
+                return cachedFaction;
+            }
+
+            var def = GravshipCrashesDefOf.Gravship_Survivors;
+            if (def == null)
+            {
+                return null;
+            }
+
+            cachedFaction = Find.FactionManager.FirstFactionOfDef(def);
+            if (cachedFaction == null)
+            {
+                cachedFaction = FactionGenerator.NewGeneratedFaction(def);
+                cachedFaction.hidden = true;
+                Find.FactionManager.Add(cachedFaction);
+            }
+
+            return cachedFaction;
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Util/GravshipCrashesDefOf.cs
+++ b/1.6/Source/GravshipCrashes/Util/GravshipCrashesDefOf.cs
@@ -1,0 +1,21 @@
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace GravshipCrashes.Util
+{
+    [DefOf]
+    public static class GravshipCrashesDefOf
+    {
+        public static SitePartDef CrashedGravshipSitePart;
+        public static WorldObjectDef CrashedGravshipSite;
+        public static ThingSetMakerDef GravshipCrashLoot;
+        public static IncidentDef CrashedGravshipIncident;
+        public static FactionDef Gravship_Survivors;
+
+        static GravshipCrashesDefOf()
+        {
+            DefOfHelper.EnsureInitializedInCtor(typeof(GravshipCrashesDefOf));
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Util/GravshipLayoutSpawner.cs
+++ b/1.6/Source/GravshipCrashes/Util/GravshipLayoutSpawner.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace GravshipCrashes.Util
+{
+    /// <summary>
+    /// Attempts to place ship layouts exported by the Gravship Exporter mod.
+    /// </summary>
+    public static class GravshipLayoutSpawner
+    {
+        private static readonly Dictionary<Type, MethodInfo> PlacementMethods = new();
+
+        public static bool TrySpawnLayout(Map map, ShipLayoutResolver.ShipEntry entry, IntVec3 center, List<Thing> placedThings)
+        {
+            if (map == null || entry == null)
+            {
+                return false;
+            }
+
+            var type = entry.RawDef?.GetType();
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (!PlacementMethods.TryGetValue(type, out var placementMethod))
+            {
+                placementMethod = ResolvePlacementMethod(type);
+                PlacementMethods[type] = placementMethod;
+            }
+
+            if (placementMethod != null)
+            {
+                try
+                {
+                    var parameters = placementMethod.GetParameters();
+                    var args = BuildArguments(parameters, map, center, entry.RawDef);
+                    if (args != null)
+                    {
+                        var result = placementMethod.Invoke(entry.RawDef, args);
+                        if (result is bool success && success)
+                        {
+                            CollectPlacedThings(map, placedThings, center, 50);
+                            return true;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning("[GravshipCrashes] Failed to invoke ShipLayout placement method: " + ex);
+                }
+            }
+
+            return false;
+        }
+
+        private static MethodInfo ResolvePlacementMethod(Type type)
+        {
+            foreach (var method in type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (method.ReturnType != typeof(bool))
+                {
+                    continue;
+                }
+
+                var parameters = method.GetParameters();
+                if (parameters.Length < 2)
+                {
+                    continue;
+                }
+
+                if (parameters[0].ParameterType != typeof(Map))
+                {
+                    continue;
+                }
+
+                return method;
+            }
+
+            return null;
+        }
+
+        private static object[] BuildArguments(ParameterInfo[] parameters, Map map, IntVec3 center, object def)
+        {
+            if (parameters == null || parameters.Length == 0)
+            {
+                return null;
+            }
+
+            var args = new object[parameters.Length];
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var type = parameters[i].ParameterType;
+                if (type == typeof(Map))
+                {
+                    args[i] = map;
+                }
+                else if (type == typeof(IntVec3))
+                {
+                    args[i] = center;
+                }
+                else if (type == typeof(Rot4))
+                {
+                    args[i] = Rot4.North;
+                }
+                else if (type == typeof(bool))
+                {
+                    args[i] = true;
+                }
+                else if (type == typeof(ThingDef))
+                {
+                    args[i] = ThingDefOf.ShipChunk;
+                }
+                else if (type == def?.GetType())
+                {
+                    args[i] = def;
+                }
+                else
+                {
+                    args[i] = type.IsValueType ? Activator.CreateInstance(type) : null;
+                }
+            }
+
+            return args;
+        }
+
+        public static CellRect CalculateBounds(List<Thing> placedThings, Map map)
+        {
+            if (placedThings == null || placedThings.Count == 0)
+            {
+                return CellRect.CenteredOn(map.Center, 20, 20);
+            }
+
+            var min = new IntVec3(int.MaxValue, 0, int.MaxValue);
+            var max = new IntVec3(int.MinValue, 0, int.MinValue);
+
+            foreach (var thing in placedThings)
+            {
+                if (thing == null)
+                {
+                    continue;
+                }
+
+                min.x = Mathf.Min(min.x, thing.Position.x);
+                min.z = Mathf.Min(min.z, thing.Position.z);
+                max.x = Mathf.Max(max.x, thing.Position.x);
+                max.z = Mathf.Max(max.z, thing.Position.z);
+            }
+
+            var width = Mathf.Max(10, max.x - min.x + 10);
+            var height = Mathf.Max(10, max.z - min.z + 10);
+
+            return CellRect.CenteredOn(map.Center, width, height).ClipInsideMap(map);
+        }
+
+        private static void CollectPlacedThings(Map map, List<Thing> results, IntVec3 center, int radius)
+        {
+            if (results == null)
+            {
+                return;
+            }
+
+            var cells = GenRadial.RadialCellsAround(center, radius, true);
+            foreach (var cell in cells)
+            {
+                if (!cell.InBounds(map))
+                {
+                    continue;
+                }
+
+                results.AddRange(cell.GetThingList(map));
+            }
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Util/GravshipSpawnUtility.cs
+++ b/1.6/Source/GravshipCrashes/Util/GravshipSpawnUtility.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GravshipCrashes.Settings;
+using RimWorld;
+using RimWorld.Planet;
+using UnityEngine;
+using Verse;
+
+namespace GravshipCrashes.Util
+{
+    /// <summary>
+    /// Helpers for creating world sites and generating the crashed gravship map experience.
+    /// </summary>
+    public static class GravshipSpawnUtility
+    {
+        private static readonly string[] GravEngineDefNames =
+        {
+            "ShipGravEngine", "ShipPart_GravEngine", "VFEI_GravEngine", "SOS2_ShipGravEngine"
+        };
+
+        public static bool TryFindSiteTile(out int tile)
+        {
+            return TileFinder.TryFindNewSiteTile(out tile, 6, 30, false, TileFinderMode.Nearby, -1);
+        }
+
+        public static Site CreateSite(int tile)
+        {
+            var siteDef = GravshipCrashesDefOf.CrashedGravshipSite;
+            var site = (Site)WorldObjectMaker.MakeWorldObject(siteDef);
+            site.Tile = tile;
+            site.SetFaction(null);
+
+            var part = new SitePart
+            {
+                def = GravshipCrashesDefOf.CrashedGravshipSitePart,
+                site = site,
+                parms = new SitePartParams
+                {
+                    threatPoints = 0f,
+                    pawnGroupKindDef = PawnGroupKindDefOf.Combat
+                }
+            };
+
+            site.parts.Add(part);
+            site.customLabel = "Crashed Gravship";
+
+            return site;
+        }
+
+        public static void ConfigureTimeout(Site site, IntRange daysRange)
+        {
+            var timeout = site.GetComponent<TimeoutComp>();
+            if (timeout != null)
+            {
+                timeout.StartTimeout(daysRange.RandomInRange * 60000);
+            }
+        }
+
+        public static void ConfigureSiteMetadata(Site site, ShipLayoutResolver.ShipEntry entry)
+        {
+            var comp = site.GetComponent<WorldObjectComp_CrashedGravship>();
+            if (comp == null)
+            {
+                return;
+            }
+
+            comp.ShipDefName = entry?.DefName ?? string.Empty;
+            comp.StructureDamageSeed = Rand.Int;
+            comp.ThingDamageSeed = Rand.Int;
+            comp.LootSeed = Rand.Int;
+            comp.DefenderSeed = Rand.Int;
+        }
+
+        public static void RemoveGravEngines(Map map, IEnumerable<IntVec3> candidateCells)
+        {
+            if (map == null)
+            {
+                return;
+            }
+
+            var cells = candidateCells?.ToList() ?? new List<IntVec3>();
+            foreach (var cell in cells)
+            {
+                RemoveGravEnginesAt(map, cell);
+            }
+
+            foreach (var thing in map.listerThings.AllThings.ToList())
+            {
+                if (thing.def != null && GravEngineDefNames.Contains(thing.def.defName))
+                {
+                    var cell = thing.Position;
+                    thing.Destroy(DestroyMode.KillFinalize);
+                    PlaceWreckage(map, cell);
+                }
+            }
+        }
+
+        private static void RemoveGravEnginesAt(Map map, IntVec3 cell)
+        {
+            var things = cell.GetThingList(map);
+            for (var i = things.Count - 1; i >= 0; i--)
+            {
+                var thing = things[i];
+                if (thing?.def == null)
+                {
+                    continue;
+                }
+
+                if (!GravEngineDefNames.Contains(thing.def.defName))
+                {
+                    continue;
+                }
+
+                thing.Destroy(DestroyMode.KillFinalize);
+                PlaceWreckage(map, cell);
+            }
+        }
+
+        private static void PlaceWreckage(Map map, IntVec3 cell)
+        {
+            var slag = ThingMaker.MakeThing(ThingDefOf.ChunkSlagSteel);
+            GenPlace.TryPlaceThing(slag, cell, map, ThingPlaceMode.Direct);
+
+            if (map.weatherManager.RainRate < 0.5f)
+            {
+                FireUtility.TryStartFireIn(cell, map, Rand.Range(0.1f, 0.2f));
+            }
+        }
+
+        public static void ApplyStructureDamage(Map map, FloatRange damageRange, int seed)
+        {
+            Rand.PushState(seed);
+            try
+            {
+                foreach (var building in map.listerThings.ThingsInGroup(ThingRequestGroup.BuildingArtificial))
+                {
+                    if (!building.def.useHitPoints || building.Destroyed)
+                    {
+                        continue;
+                    }
+
+                    var damageFraction = damageRange.RandomInRange;
+                    if (Rand.Value < damageFraction)
+                    {
+                        var hitPoints = Mathf.Max(1, Mathf.RoundToInt(building.MaxHitPoints * (1f - damageFraction)));
+                        building.HitPoints = Mathf.Clamp(hitPoints, 1, building.MaxHitPoints);
+                        if (Rand.Value < 0.25f)
+                        {
+                            building.TakeDamage(new DamageInfo(DamageDefOf.Bomb, Mathf.Max(5f, building.MaxHitPoints * damageFraction * 0.5f)));
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                Rand.PopState();
+            }
+        }
+
+        public static void ApplyThingDamage(Map map, FloatRange damageRange, int seed)
+        {
+            Rand.PushState(seed);
+            try
+            {
+                foreach (var thing in map.listerThings.AllThings)
+                {
+                    if (thing is Pawn || !thing.def.useHitPoints || thing.Destroyed)
+                    {
+                        continue;
+                    }
+
+                    if (thing.def.category == ThingCategory.Building)
+                    {
+                        continue; // handled by structure damage
+                    }
+
+                    var damageFraction = damageRange.RandomInRange;
+                    if (Rand.Value < damageFraction)
+                    {
+                        thing.HitPoints = Mathf.Max(1, Mathf.RoundToInt(thing.MaxHitPoints * (1f - damageFraction)));
+                        if (Rand.Value < 0.1f)
+                        {
+                            thing.Destroy(DestroyMode.KillFinalize);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                Rand.PopState();
+            }
+        }
+
+        public static void ScatterDebris(Map map, CellRect area, int seed)
+        {
+            Rand.PushState(seed);
+            try
+            {
+                var debrisCount = Mathf.Clamp(area.Area / 25, 6, 40);
+                for (var i = 0; i < debrisCount; i++)
+                {
+                    var cell = area.RandomCell;
+                    if (!cell.InBounds(map) || !cell.Walkable(map))
+                    {
+                        continue;
+                    }
+
+                    FilthMaker.TryMakeFilth(cell, map, ThingDefOf.FilthAsh);
+                    if (Rand.Chance(0.35f))
+                    {
+                        FireUtility.TryStartFireIn(cell, map, Rand.Range(0.05f, 0.2f));
+                    }
+                }
+            }
+            finally
+            {
+                Rand.PopState();
+            }
+        }
+
+        public static void SpawnLoot(Map map, CellRect area, int seed)
+        {
+            if (GravshipCrashesDefOf.GravshipCrashLoot == null)
+            {
+                return;
+            }
+
+            Rand.PushState(seed);
+            try
+            {
+                var parms = default(ThingSetMakerParams);
+                parms.totalMarketValueRange = new FloatRange(300f, 900f);
+                parms.techLevel = TechLevel.Spacer;
+
+                var loot = GravshipCrashesDefOf.GravshipCrashLoot.root.Generate(parms);
+                foreach (var thing in loot)
+                {
+                    var cell = area.RandomCell;
+                    if (!cell.InBounds(map))
+                    {
+                        cell = CellFinderLoose.TryFindCentralCell(map, 5f) ?? map.Center;
+                    }
+
+                    GenPlace.TryPlaceThing(thing, cell, map, ThingPlaceMode.Near);
+                }
+            }
+            finally
+            {
+                Rand.PopState();
+            }
+        }
+    }
+}

--- a/1.6/Source/GravshipCrashes/Util/ShipLayoutResolver.cs
+++ b/1.6/Source/GravshipCrashes/Util/ShipLayoutResolver.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using GravshipCrashes.Settings;
+using RimWorld;
+using Verse;
+
+namespace GravshipCrashes.Util
+{
+    /// <summary>
+    /// Discovers and exposes ShipLayoutDefV2 defs provided by the Gravship Exporter mod.
+    /// </summary>
+    public static class ShipLayoutResolver
+    {
+        private const string LayoutTypeName = "ShipLayoutDefV2";
+        private static Type shipLayoutType;
+        private static readonly List<ShipEntry> allShips = new List<ShipEntry>();
+        private static bool missingExporterWarningPrinted;
+
+        /// <summary>
+        /// Information about a ship layout option.
+        /// </summary>
+        public class ShipEntry
+        {
+            public string DefName { get; internal set; } = string.Empty;
+            public string Label { get; internal set; } = string.Empty;
+            public string SourceMod { get; internal set; } = string.Empty;
+            internal Def Def { get; set; }
+            internal object RawDef { get; set; }
+
+            public string LabelWithSource => string.IsNullOrEmpty(SourceMod) ? Label : $"{Label} ({SourceMod})";
+        }
+
+        public static IReadOnlyList<ShipEntry> AllShips => allShips;
+
+        public static IEnumerable<string> AllShipsDefNames => allShips.Select(s => s.DefName);
+
+        public static bool HasExporterContent => shipLayoutType != null && allShips.Count > 0;
+
+        public static void RefreshIfNeeded()
+        {
+            if (shipLayoutType != null && allShips.Count > 0)
+            {
+                return;
+            }
+
+            Refresh();
+        }
+
+        public static void Refresh()
+        {
+            allShips.Clear();
+            missingExporterWarningPrinted = false;
+
+            shipLayoutType = GenTypes.GetTypeInAnyAssembly(LayoutTypeName);
+            if (shipLayoutType == null)
+            {
+                WarnMissingExporter();
+                return;
+            }
+
+            try
+            {
+                var dbType = typeof(DefDatabase<>).MakeGenericType(shipLayoutType);
+                var prop = dbType.GetProperty("AllDefsListForReading", BindingFlags.Static | BindingFlags.Public);
+                if (prop?.GetValue(null) is IEnumerable enumerable)
+                {
+                    foreach (var obj in enumerable)
+                    {
+                        if (obj is Def def)
+                        {
+                            var entry = new ShipEntry
+                            {
+                                DefName = def.defName,
+                                Label = def.LabelCap.NullOrEmpty() ? def.label : def.LabelCap,
+                                SourceMod = def.modContentPack?.Name ?? string.Empty,
+                                Def = def,
+                                RawDef = obj
+                            };
+
+                            allShips.Add(entry);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[GravshipCrashes] Failed to enumerate ShipLayoutDefV2 defs: " + ex);
+            }
+
+            allShips.Sort((a, b) => string.Compare(a.Label, b.Label, StringComparison.OrdinalIgnoreCase));
+
+            if (allShips.Count == 0)
+            {
+                WarnMissingExporter();
+            }
+        }
+
+        public static void NotifySettingsChanged()
+        {
+            missingExporterWarningPrinted = false;
+        }
+
+        public static bool TryGetEntry(string defName, out ShipEntry entry)
+        {
+            entry = allShips.FirstOrDefault(e => string.Equals(e.DefName, defName, StringComparison.OrdinalIgnoreCase));
+            return entry != null;
+        }
+
+        public static List<ShipEntry> AllowedShips(ModSettings_GravshipCrashes settings)
+        {
+            var result = new List<ShipEntry>();
+            if (settings == null)
+            {
+                return result;
+            }
+
+            foreach (var ship in allShips)
+            {
+                if (settings.AllowsShip(ship.DefName))
+                {
+                    result.Add(ship);
+                }
+            }
+
+            return result;
+        }
+
+        public static bool TryResolveLayoutWorker(ShipEntry entry, out object worker)
+        {
+            worker = null;
+            if (entry?.RawDef == null)
+            {
+                return false;
+            }
+
+            var workerField = shipLayoutType?.GetField("resolvedLayout", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (workerField != null)
+            {
+                worker = workerField.GetValue(entry.RawDef);
+                if (worker != null)
+                {
+                    return true;
+                }
+            }
+
+            var property = shipLayoutType?.GetProperty("ResolvedLayout", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (property != null)
+            {
+                worker = property.GetValue(entry.RawDef);
+                return worker != null;
+            }
+
+            return false;
+        }
+
+        private static void WarnMissingExporter()
+        {
+            if (missingExporterWarningPrinted)
+            {
+                return;
+            }
+
+            missingExporterWarningPrinted = true;
+            Log.Warning("[GravshipCrashes] ShipLayoutDefV2 type not found. Install the Gravship Exporter mod to enable crashed gravship sites.");
+        }
+    }
+}

--- a/About/About.xml
+++ b/About/About.xml
@@ -16,4 +16,5 @@
                         <downloadUrl>https://github.com/JohnCannon87/RimworldCustomShipStart</downloadUrl>
             </li>
         </modDependencies>
+        <modClass>GravshipCrashes.Settings.Mod_GravshipCrashes</modClass>
 </ModMetaData>


### PR DESCRIPTION
## Summary
- add storyteller incident and world site definitions for crashed gravships, including a custom site part and world object with timeout tracking
- implement site map generation, defender spawning, grav-engine removal, loot scatter, and reflection-based ship layout resolution that integrates with ShipLayoutDefV2 when available
- expose comprehensive mod settings (frequency, damage, defenders, ship filtering, dev toggle) and a world debug action for quick site spawning

## Settings
- storyteller frequency controls (days between crash checks, base chance)
- damage tuning sliders for ship structure, things, and pawn injuries
- defender cap and ship layout checkbox filter populated at runtime
- optional dev-mode world spawn debug button toggle

## How to test
- load RimWorld with this mod and the Gravship Exporter active
- open Mod Settings → Gravship Crashes and adjust sliders / ship list; restart to confirm persistence
- use Dev Mode on the world map → Gravship Crashes → Spawn Crashed Gravship Site (Dev) to generate a site, enter it, and observe layout, fires, damage, defenders, and loot
- trigger the "crashed gravship" incident via Debug Actions menu to ensure a timed world site appears with the correct letter

## Known limitations
- ship layout placement relies on reflection heuristics and falls back to a simple hull if the exporter API changes or no layout method can be resolved
- grav-engine identification uses a curated defName list until the exporter exposes a dedicated API


------
https://chatgpt.com/codex/tasks/task_e_68dc4cf590f883208987d75ded4474ba